### PR TITLE
Create EventInformation view

### DIFF
--- a/src/components/Client/Client.js
+++ b/src/components/Client/Client.js
@@ -6,6 +6,7 @@ import DataAdapter from "utilities/APIHandler/dataAdapter";
 import "./Client.scss";
 import ClientInformation from "./ClientInformation";
 import PackageInformation from "./PackageInformation";
+import EventInformation from "./EventInformation";
 
 const Client = ({ apiHandler, client_uuid }) => {
     const [errors, setErrors] = useState(false);
@@ -39,8 +40,23 @@ const Client = ({ apiHandler, client_uuid }) => {
                 <section className="client-workflow">
                 </section>
             </section>
-            <ClientInformation client={clientData.client} apiHandler={apiHandler} setClient={setClient} />
-            <PackageInformation clientPackage={clientPackage} apiHandler={apiHandler} setPackage={setPackage} client_uuid={client_uuid} />
+            <ClientInformation 
+                client={clientData.client} 
+                apiHandler={apiHandler} 
+                setClient={setClient} 
+            />
+            <PackageInformation 
+                clientPackage={clientPackage} 
+                apiHandler={apiHandler} 
+                setPackage={setPackage} 
+                client_uuid={client_uuid} 
+            />
+            <EventInformation 
+                events={clientEvents} 
+                apiHandler={apiHandler} 
+                setEvents={setEvents} 
+                eventPackage={clientPackage} 
+            />
         </ClientPage>
     )
 }

--- a/src/components/Client/Client.scss
+++ b/src/components/Client/Client.scss
@@ -5,6 +5,7 @@
     grid-template-columns: repeat(3fr, 1fr);
     grid-template-areas:    "workflow workflow workflow info"
                             "workflow workflow workflow package"
+                            "workflow workflow workflow events"
                             "workflow workflow workflow events";
     grid-gap: 30px;
     max-width: $max-width;
@@ -43,8 +44,13 @@
     grid-area: package;
 }
 
+.client-events--container  {
+    grid-area: events;
+}
+
 .client-information--container,
-.client-package--container {
+.client-package--container,
+.client-events--container {
 
     .client-page--header {
         display: flex;
@@ -61,9 +67,9 @@
 }
 
 
-
 .client-information,
-.package-information {
+.package-information,
+.event-information {
     color: $grey-800;
     box-sizing: border-box;
     background-color: white;
@@ -80,14 +86,14 @@
     h4 {
         font-size: 16px;
         font-weight: 700;
-        margin: 0px 0px 20px 0px;
+        margin: 0px 0px 14px 0px;
     }
 
     hr {
         grid-column: 1 / -1;
         width: 100%;
-        border-top: 1px solid $grey-300;
-        margin-bottom: 20px;
+        border-top: 1px solid $grey-200;
+        margin-bottom: 10px;
     }
 
     span {
@@ -95,13 +101,18 @@
     }
 }
 
-.client-information {
+.client-information,
+.event-information {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     grid-gap: 10px;
     justify-items: start;
     align-items: start;
     text-align: left;
+}
+
+.event-information {
+    margin-bottom: 30px;
 }
 
 .package-information  {

--- a/src/components/Client/Client.test.js
+++ b/src/components/Client/Client.test.js
@@ -12,7 +12,7 @@ describe('Client', () => {
 
     const user_uuid = "1234";
 
-    it('renders client and package information', async () => {
+    it('renders client, package and events information', async () => {
         const client = MockApiData.successData(
             MockApiData.allClientData({ uuid: user_uuid })
         )
@@ -33,5 +33,19 @@ describe('Client', () => {
         getByText(/wedding premier/i)
         getByText(/Eight Hours of Photographic Coverage/i)
         getAllByText(/4800.00/i)
+
+        getByText(/engagement event/i)
+        getAllByText(/April 17, 2020/i)
+        getByText(/Have clients bring extra flowers and a see through chair./i)
+        getByText(/Los Angeles Poppy Fields/i)
+        getByText(/6AM - 11AM/i)
+
+        getByText(/wedding event/i)
+        getByText(/August 17, 2020/i)
+        getByText(/Cindy, 111-111-1111/i)
+        getByText(/Redbird DTLA/i)
+        getByText(/8AM - 11PM/i)
+        getByText(/Viviana DTLA/i)
+        getByText(/Coordinate with Cindy on exact time details for bride prep/i)
     })
 })

--- a/src/components/Client/EventInformation.js
+++ b/src/components/Client/EventInformation.js
@@ -1,0 +1,107 @@
+import React from "react";
+import DataAdapter from "utilities/APIHandler/dataAdapter";
+
+const EventInformation = ({ events, apiHandler, setEvents, eventPackage }) => {
+    if (events && events.length >= 1) {
+        return (
+            <section className="client-events--container">
+                {events.map(event => <EventModule event={event} />)}
+            </section>
+        )
+    } else if (eventPackage.wedding_included || eventPackage.engagement_included) {
+        let eventModules = [];
+        if (eventPackage.engagement_included) {
+            const intiialEventData = DataAdapter.toEventModel(null, "event");
+            eventModules.push(<EventModule key="engagement" event={intiialEventData} />)
+        }
+        if (eventPackage.wedding_included) {
+            const intiialWeddingEventData = DataAdapter.toEventModel(null, "wedding");
+            eventModules.push(<EventModule key="wedding" event={intiialWeddingEventData} />)
+        }
+        return (
+            <section className="client-events--container">
+                {eventModules}
+            </section>
+        )
+    } else {
+        return null;
+    }
+}
+
+export default EventInformation;
+
+const EventModule = ({ event }) => {
+    const {
+        blog_link,
+        edit_image_deadline,
+        event_name,
+        gallery_link,
+        notes,
+        shoot_date,
+        shoot_time,
+        shoot_location
+    } = event;
+    return (
+        <>
+            <div className="client-page--header">
+                <h1>{event_name} Event</h1>
+            </div>
+            <section className="event-information">
+                <div>
+                    <h6 className="label">{event_name} Shoot Date</h6>
+                    <h4 className="text">{shoot_date}</h4>
+
+                    <h6 className="label">{event_name} Shoot Time</h6>
+                    <h4 className="text">{shoot_time}</h4>
+
+                    {shoot_location && (
+                        <>
+                            <h6 className="label">{event_name} Shoot Location</h6>
+                            <h4 className="text">{shoot_location}</h4>
+                        </>
+                    )}
+                </div>
+                {event_name.match(/wedding/i) && <WeddingEventInfo event={event} />}
+                <hr />
+                <div>
+                    <h6 className="label">{event_name} Gallery Link</h6>
+                    <h4 className="text">{gallery_link}</h4>
+                </div>
+                <div>
+                    <h6 className="label">{event_name} Blog Link</h6>
+                    <h4 className="text">{blog_link}</h4>
+                </div>
+                <div>
+                    <h6 className="label">{event_name} Images Edit Deadline</h6>
+                    <h4 className="text">{edit_image_deadline}</h4>
+                </div>
+                <hr />
+                <span>
+                    <h6 className="label">{event_name} Notes</h6>
+                    <h4 className="text">{notes}</h4>
+                </span>
+            </section>
+        </>
+    )
+}
+
+const WeddingEventInfo = ({ event }) => {
+    const {
+        coordinator_name,
+        event_name,
+        reception_location,
+        wedding_location,
+    } = event;
+    return (
+        <div>
+            <h6 className="label">Ceremony Location</h6>
+            <h4 className="text">{wedding_location}</h4>
+
+            <h6 className="label">Reception Location</h6>
+            <h4 className="text">{reception_location}</h4>
+
+            <h6 className="label">{event_name} Coordinator</h6>
+            <h4 className="text">{coordinator_name}</h4>
+        </div>
+    )
+}

--- a/src/tests/EventFlow.test.js
+++ b/src/tests/EventFlow.test.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { App } from 'App';
+import { MemoryRouter } from "react-router-dom";
+import { render, cleanup, waitForElement, fireEvent } from '@testing-library/react';
+import MockAPIHandler from 'utilities/APIHandler/mockApiHandler';
+import Endpoints from "utilities/apiEndpoint";
+import MockApiData from "utilities/APIHandler/mockApiData";
+
+describe('Event Creation & Update Flow', () => {
+    afterEach(() => {
+        cleanup();
+    })
+
+    const user_uuid = "1234";
+    const client_uuid = "1111";
+    const package_uuid = "1111";
+    const authUser = { uuid: user_uuid, avatar: "avatar-image-link" };
+    it(`- renders no event module if there is no existing client events, 
+        - creates empty event modules if package is toggled to include wedding and/or engagement
+    `, async () => {
+        const client = MockApiData.successfulClient({ 
+            uuid: client_uuid, 
+            contacts: [MockApiData.contactData({ first_name: "Natasha" })] ,
+            package: MockApiData.packageData({ uuid: package_uuid })
+        })
+        const updatedPackage = MockApiData.successfulClient(MockApiData.packageData({ 
+            includes_engagement: true,
+            includes_wedding: true,
+            uuid: package_uuid
+        }))
+        const apiHandler = new MockAPIHandler({ 
+            [Endpoints.getClient(client_uuid)]: [client],
+            [Endpoints.updatePackage(package_uuid)]: [updatedPackage]
+        });
+        const { findByText, getByText, getAllByText, getByLabelText } = render(
+            <MemoryRouter initialEntries={[`/client/${client_uuid}`]} initialIndex={0}>
+                <App apiHandler={apiHandler} authUser={authUser}/>
+            </MemoryRouter>
+        )
+
+        await waitForElement(() =>
+            findByText(/Natasha Lee/i)
+        )
+
+        fireEvent.click(getAllByText("Edit")[1]);
+        
+        await waitForElement(() =>
+            findByText(/update package/i)
+        )
+
+        const includeEngagement = getByLabelText("Includes Engagement Event");
+        fireEvent.click(includeEngagement);
+
+        const includeWedding = getByLabelText("Includes Wedding Event");
+        fireEvent.click(includeWedding);
+
+        fireEvent.click(getByText("Update Package"));
+
+        await waitForElement(() =>
+            findByText(/Natasha Lee/i)
+        )
+        getByText(/engagement shoot location/i)
+        getByText(/ceremony location/i)
+    })
+})

--- a/src/tests/UpdateClientFlow.test.js
+++ b/src/tests/UpdateClientFlow.test.js
@@ -92,12 +92,12 @@ describe('Update Client Flow - Client Information', () => {
         await waitForElement(() =>
             findByText(/Zihao Zui/i)
         )
-        findByText(/natasha@gmail.com/i)
-        findByText(/111-111-1111/i)
-        findByText(/Referred by Pat/i)
-        findByText(/Zihao Zui/i)
-        findByText(/zihao@gmail.com/i)
-        findByText(/333-333-3333/i)
+        getByText(/natasha@gmail.com/i)
+        getAllByText(/111-111-1111/i)
+        getByText(/Referred by Pat/i)
+        getByText(/Zihao Zui/i)
+        getByText(/zihao@gmail.com/i)
+        getByText(/333-333-3333/i)
     })
 
     it(`renders the updated information after successful client package update`, async () => {
@@ -155,8 +155,8 @@ describe('Update Client Flow - Client Information', () => {
         await waitForElement(() =>
             findByText(/Natasha Lee/i)
         )
-        findByText(/wedding classic/i)
-        findAllByText(/$5000.00/i)
-        findByText(/8 Hours of Photographic Coverage/i)
+        getByText(/wedding classic/i)
+        getAllByText(/5000.00/i)
+        getByText(/8 Hours of Photographic Coverage/i)
     })
 })

--- a/src/utilities/APIHandler/dataAdapter.test.js
+++ b/src/utilities/APIHandler/dataAdapter.test.js
@@ -63,7 +63,33 @@ describe("Data Adapter", () => {
             "event_name": "Engagement",
             "package_uuid": "654a66f1-055f-4525-906e-9334e28b1966",
             "shoot_date": "April 17, 2020",
-            "uuid": "6607cce2-0d61-4fb9-8caa-058fc62c73ca"
+            "uuid": "6607cce2-0d61-4fb9-8caa-058fc62c73ca",
+            "blog_link": "http://google.com",
+            "edit_image_deadline": "April 17, 2020",
+            "gallery_link": "http://google.com",
+            "notes": "Have clients bring extra flowers and a see through chair.",
+            "shoot_location": "Los Angeles Poppy Fields",
+            "shoot_time": "6AM - 11AM",
+        })
+    })
+
+    it("maps Event API data to a WeddingEventModel", () => {
+        let apiEventData = MockApiData.weddingEventData()
+        const weddingEventModel = DataAdapter.toEventModel(apiEventData);
+
+        expect(weddingEventModel).toEqual({
+            "event_name": "Wedding",
+            "package_uuid": "654a66f1-055f-4525-906e-9334e28b1966",
+            "shoot_date": "August 17, 2020",
+            "uuid": "6607cce2-0d61-4fb9-8caa-058fc62c73ca",
+            "blog_link": "http://google.com",
+            "coordinator_name": "Cindy, 111-111-1111",
+            "edit_image_deadline": "April 17, 2020",
+            "gallery_link": "http://google.com",
+            "notes": "Coordinate with Cindy on exact time details for bride prep",
+            "reception_location": "Redbird DTLA",
+            "shoot_time": "8AM - 11PM",
+            "wedding_location": "Viviana DTLA",
         })
     })
 
@@ -74,7 +100,7 @@ describe("Data Adapter", () => {
         expect(packageModel).toEqual({
             "package_name": "Wedding Premier",
             "uuid": "654a66f1-055f-4525-906e-9334e28b1966",
-            "upcoming_shoot_date": "July 17, 2020",
+            "upcoming_shoot_date": "April 17, 2020",
             "balance_received": false,
             "balance_remaining": "4800.00",
             "discount_offered": "0.00",
@@ -136,7 +162,7 @@ describe("Data Adapter", () => {
             "package": {
                 "package_name": "Wedding Premier",
                 "uuid": "654a66f1-055f-4525-906e-9334e28b1966",
-                "upcoming_shoot_date": "July 17, 2020",
+                "upcoming_shoot_date": "April 17, 2020",
                 "balance_received": false,
                 "balance_remaining": "4800.00",
                 "discount_offered": "0.00",
@@ -158,20 +184,34 @@ describe("Data Adapter", () => {
                 engagement_included: false,
                 wedding_included: false
             },
-            "events": {
-                "Engagement": {
+            "events": [
+                {
                     "event_name": "Engagement",
                     "package_uuid": "654a66f1-055f-4525-906e-9334e28b1966",
-                    "shoot_date": "July 17, 2020",
-                    "uuid": "6607cce2-0d61-4fb9-8caa-058fc62c73ca"
+                    "shoot_date": "April 17, 2020",
+                    "uuid": "6607cce2-0d61-4fb9-8caa-058fc62c73ca",
+                    "blog_link": "http://google.com",
+                    "edit_image_deadline": "April 17, 2020",
+                    "gallery_link": "http://google.com",
+                    "notes": "Have clients bring extra flowers and a see through chair.",
+                    "shoot_location": "Los Angeles Poppy Fields",
+                    "shoot_time": "6AM - 11AM",
                 },
-                "Wedding": {
+                {
                     "event_name": "Wedding",
                     "package_uuid": "654a66f1-055f-4525-906e-9334e28b1966",
-                    "shoot_date": "April 17, 2020",
-                    "uuid": "6607cce2-0d61-4fb9-8caa-058fc62c73ca"
+                    "shoot_date": "August 17, 2020",
+                    "uuid": "6607cce2-0d61-4fb9-8caa-058fc62c73ca",
+                    "blog_link": "http://google.com",
+                    "coordinator_name": "Cindy, 111-111-1111",
+                    "edit_image_deadline": "April 17, 2020",
+                    "gallery_link": "http://google.com",
+                    "notes": "Coordinate with Cindy on exact time details for bride prep",
+                    "reception_location": "Redbird DTLA",
+                    "shoot_time": "8AM - 11PM",
+                    "wedding_location": "Viviana DTLA",
                 }
-            }
+            ]
         }])
     })
 

--- a/src/utilities/APIHandler/mockApiData.js
+++ b/src/utilities/APIHandler/mockApiData.js
@@ -75,7 +75,35 @@ const MockApiData = {
             "event_name": "Engagement",
             "package_uuid": "654a66f1-055f-4525-906e-9334e28b1966",
             "shoot_date": "2020-04-17T14:00:00Z",
-            "uuid": "6607cce2-0d61-4fb9-8caa-058fc62c73ca"
+            "uuid": "6607cce2-0d61-4fb9-8caa-058fc62c73ca",
+            "blog_link": "http://google.com",
+            "coordinator_name": null,
+            "edit_image_deadline": "2020-04-17T14:00:00Z",
+            "gallery_link": "http://google.com",
+            "notes": "Have clients bring extra flowers and a see through chair.",
+            "reception_location": null,
+            "shoot_location": "Los Angeles Poppy Fields",
+            "shoot_time": "6AM - 11AM",
+            "wedding_location": null
+        }
+        return Object.assign(apiData, dataObject);
+    },
+    weddingEventData: (dataObject) => {
+        let apiData = {
+            "client_uuid": "cc14121c-ff53-4edb-832b-8adda60cb372",
+            "event_name": "Wedding",
+            "package_uuid": "654a66f1-055f-4525-906e-9334e28b1966",
+            "shoot_date": "2020-08-17T14:00:00Z",
+            "uuid": "6607cce2-0d61-4fb9-8caa-058fc62c73ca",
+            "blog_link": "http://google.com",
+            "coordinator_name": "Cindy, 111-111-1111",
+            "edit_image_deadline": "2020-04-17T14:00:00Z",
+            "gallery_link": "http://google.com",
+            "notes": "Coordinate with Cindy on exact time details for bride prep",
+            "reception_location": "Redbird DTLA",
+            "shoot_location": null,
+            "shoot_time": "8AM - 11PM",
+            "wedding_location": "Viviana DTLA"
         }
         return Object.assign(apiData, dataObject);
     },
@@ -83,20 +111,8 @@ const MockApiData = {
         let apiData = {
             "client_uuid": "cc14121c-ff53-4edb-832b-8adda60cb372",
             "package_events": [
-                {
-                    "client_uuid": "cc14121c-ff53-4edb-832b-8adda60cb372",
-                    "event_name": "Engagement",
-                    "package_uuid": "654a66f1-055f-4525-906e-9334e28b1966",
-                    "shoot_date": "2020-07-17T14:00:00Z",
-                    "uuid": "6607cce2-0d61-4fb9-8caa-058fc62c73ca"
-                },
-                {
-                    "client_uuid": "cc14121c-ff53-4edb-832b-8adda60cb372",
-                    "event_name": "Wedding",
-                    "package_uuid": "654a66f1-055f-4525-906e-9334e28b1966",
-                    "shoot_date": "2020-04-17T14:00:00Z",
-                    "uuid": "6607cce2-0d61-4fb9-8caa-058fc62c73ca"
-                }
+                MockApiData.eventData(),
+                MockApiData.weddingEventData()
             ],
             "package_name": "Wedding Premier",
             proposal_signed: false,
@@ -119,7 +135,8 @@ const MockApiData = {
             balance_received: false,
             engagement_included: false,
             wedding_included: false,
-            "uuid": "654a66f1-055f-4525-906e-9334e28b1966"
+            "uuid": "654a66f1-055f-4525-906e-9334e28b1966",
+            upcoming_shoot_date: "2020-04-17T14:00:00Z",
         }
         return Object.assign(apiData, dataObject);
     },


### PR DESCRIPTION
# Things Done
If there is event information, it will render the wedding or default event modules depending on event name (it will look for "wedding" in the event_name to trigger wedding specific fields)

If there is no event information tied to a client, it will render empty event modules when a user  updates the Package information, specifically the "engagement_included" and "wedding_included" fields. It will render an engagement or wedding event module depending on what the package wants to include.  This is to prepare for editing of these values in the UpdateEventForm module to be created in the next story

- Update Event DataAdapter with new event fields. It can also return a set of initial empty values to prepare for event creation.

![Screen Shot 2019-09-19 at 1 15 11 PM](https://user-images.githubusercontent.com/29721784/65281550-b9bd4400-dae7-11e9-9c3a-aa86762a5a61.png)
![creation](https://media.giphy.com/media/S9j0dBWQCJi7bPz11x/giphy.gif)